### PR TITLE
Adds a post-package-update handler

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -34,6 +34,7 @@ class Plugin implements PluginInterface, EventSubscriberInterface
     {
         return [
             'post-package-install'  => 'onPostPackageInstall',
+            'post-package-update'  => 'onPostPackageUpdate',
             'pre-package-uninstall' => 'onPrePackageUninstall',
         ];
     }
@@ -57,6 +58,25 @@ class Plugin implements PluginInterface, EventSubscriberInterface
      */
     public function onPostPackageInstall(PackageEvent $event)
     {
+        $installer = new AssetInstaller($this->composer, $this->io);
+        $installer($event);
+    }
+
+    /**
+     * Updates assets provided by the package, if any.
+     *
+     * Uninstalls any previously installed assets for the package, and then
+     * runs an install for the package.
+     *
+     * @param PackageEvent $event
+     */
+    public function onPostPackageUpdate(PackageEvent $event)
+    {
+        // Uninstall any previously installed packages
+        $uninstall = new AssetUninstaller($this->composer, $this->io);
+        $uninstall($event);
+
+        // Install packages
         $installer = new AssetInstaller($this->composer, $this->io);
         $installer($event);
     }

--- a/test/PluginTest.php
+++ b/test/PluginTest.php
@@ -16,6 +16,7 @@ class PluginTest extends TestCase
     {
         $this->assertEquals([
             'post-package-install' => 'onPostPackageInstall',
+            'post-package-update' => 'onPostPackageUpdate',
             'pre-package-uninstall' => 'onPrePackageUninstall',
         ], Plugin::getSubscribedEvents());
     }


### PR DESCRIPTION
The new handler uses the existing AssetUninstaller and AssetInstaller to remove any assets the package previously installed, and then install those it now defines.
